### PR TITLE
优化版本管理

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build": "node build/build.js",
     "test": "npm run test:server && npm run test:client",
     "test:client": "karma start tests/karma.conf.js",
-    "test:server": "mocha --compilers js:babel-register tests/server/*"
+    "test:server": "mocha --compilers js:babel-register tests/server/*",
+    "preversion": "npm run test",
+    "version": "npm run build && git add -A dist",
+    "postversion": "git push && git push --tags"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
解决 build 文件版本号未对齐问题: [`upyun@3.3.7`](https://unpkg.com/upyun@3.3.7/dist/upyun.min.js) 中 版本号为 `3.3.6`.

方案: 将修改 `version` 和 `build` 流程合并

#### npm version 规则

https://docs.npmjs.com/cli/version.html