### PR TITLE
支持 formPutFile 函数传入 content-md5 并正确计算签名

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ client.getFile('/sample.txt', saveTo).then(function (stream) {
 
 - `remotePath`: 保存路径
 - `localFile`: 需要上传的文件，和 `putFile` 相同(**如果在浏览器端使用，只支持 String/Blob/File **)
-- `params`: 又拍云表单 api 支持的可选参数（`save-key` `service` 两个必选参数不需要手动在这里设置）
+- `params`: 又拍云表单 api 支持的可选参数（`service(同 bucket)`, `save-key` 两个必选参数不需要手动在这里设置）
 
 **响应**
 

--- a/tests/server/upyun.js
+++ b/tests/server/upyun.js
@@ -239,13 +239,15 @@ describe('index', function () {
     })
 
     it('should upload base64 encode file success', async () => {
+      const content = 'dGVzdCBiYXNlNjQgdXBsb2Fk'
       const options = {
         'content-type': 'text/plain',
         'b64encoded': 'on',
+        'content-md5': md5(content)
       }
       const result = await client.formPutFile(
         '/test-base64.txt',
-        'dGVzdCBiYXNlNjQgdXBsb2Fk',
+        content,
         options
       )
       expect(result.code).to.equal(200)

--- a/upyun/sign.js
+++ b/upyun/sign.js
@@ -69,7 +69,8 @@ export function getPolicyAndAuthorization (service, params) {
   const authorization = genSign(service, {
     method: 'POST',
     path: '/' + service.serviceName,
-    policy
+    policy,
+    contentMd5: params['content-md5']
   })
   return {
     policy,

--- a/upyun/upyun.js
+++ b/upyun/upyun.js
@@ -432,7 +432,12 @@ export default class Upyun {
     })
   }
 
-  formPutFile (remotePath, localFile, params = {}) {
+  formPutFile (remotePath, localFile, orignParams = {}) {
+    const params = {}
+    for (const key of Object.keys(orignParams)) {
+      params[key.toLowerCase()] = orignParams[key]
+    }
+
     if (typeof this.bodySignCallback !== 'function') {
       throw new Error('upyun - must setBodySignCallback first!')
     }


### PR DESCRIPTION
传入 content-md5 参数，响应返回 `message: signature error`

原因: 若参数 content-md5 存在，签名计算需要加入该参数