### PR TITLE
support proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ const client = new upyun.Client(service[, options][, getHeaderSignCallback])
 - `options`: 配置项，可以配置以下参数
   - `domain`: 又拍云 rest api 地址，默认 `v0.api.upyun.com` 其他可配置域名见又拍云[文档](http://docs.upyun.com/api/rest_api/)
   - `protocol`: 使用 `http|https` 协议，默认 `https` 协议
+  - `proxy`: 代理配置见 [axios 相关文档](https://github.com/axios/axios). 默认为 `undefined`.
 - `getHeaderSignCallback`: 获取又拍云 HTTP Header 签名回调函数，服务端使用时不需要设置该参数。客户端使用必须设置该回调函数，它接受四个参数：`service, method, path, contentMD5`, 用于计算当前请求签名，其中 `contentMD5` 可选填。如果回调函数是异步，则必须返回一个 `Promise`
 
 **示例**

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const client = new upyun.Client(service[, options][, getHeaderSignCallback])
 - `options`: 配置项，可以配置以下参数
   - `domain`: 又拍云 rest api 地址，默认 `v0.api.upyun.com` 其他可配置域名见又拍云[文档](http://docs.upyun.com/api/rest_api/)
   - `protocol`: 使用 `http|https` 协议，默认 `https` 协议
-  - `proxy`: 代理配置见 [axios 相关文档](https://github.com/axios/axios). 默认为 `undefined`.
+  - `proxy`: 代理配置见[使用说明](https://github.com/upyun/node-sdk/pull/63). 默认为 `undefined`.
 - `getHeaderSignCallback`: 获取又拍云 HTTP Header 签名回调函数，服务端使用时不需要设置该参数。客户端使用必须设置该回调函数，它接受四个参数：`service, method, path, contentMD5`, 用于计算当前请求签名，其中 `contentMD5` 可选填。如果回调函数是异步，则必须返回一个 `Promise`
 
 **示例**

--- a/upyun/create-req.js
+++ b/upyun/create-req.js
@@ -15,10 +15,11 @@ axios.defaults.adapter = (function () {
   return http
 })()
 
-export default function (endpoint, service, getHeaderSign) {
+export default function (endpoint, service, getHeaderSign, {proxy} = {}) {
   const req = axios.create({
     baseURL: endpoint + '/' + service.serviceName,
     maxRedirects: 0,
+    proxy
   })
 
   req.interceptors.request.use((config) => {

--- a/upyun/upyun.js
+++ b/upyun/upyun.js
@@ -44,6 +44,7 @@ export default class Upyun {
 
     this.endpoint = config.protocol + '://' + config.domain
     const {proxy} = config
+    this.proxy = proxy
     this.req = createReq(this.endpoint, service, getHeaderSign || defaultGetHeaderSign, {proxy})
     // NOTE this will be removed
     this.bucket = service
@@ -463,7 +464,8 @@ export default class Upyun {
     return axios.post(
       'http://purge.upyun.com/purge/',
       'purge=' + urls.join('\n'), {
-        headers
+        headers,
+        proxy: this.proxy
       }
     ).then(({data}) => {
       if (Object.keys(data.invalid_domain_of_url).length === 0) {

--- a/upyun/upyun.js
+++ b/upyun/upyun.js
@@ -38,11 +38,13 @@ export default class Upyun {
 
     const config = Object.assign({
       domain: 'v0.api.upyun.com',
-      protocol: 'https'
+      protocol: 'https',
+      // proxy: false // 禁用代理 // 参考 axios 配置. 如: {host: '127.0.0.1', post: 1081}
     }, params)
-    this.endpoint = config.protocol + '://' + config.domain
 
-    this.req = createReq(this.endpoint, service, getHeaderSign || defaultGetHeaderSign)
+    this.endpoint = config.protocol + '://' + config.domain
+    const {proxy} = config
+    this.req = createReq(this.endpoint, service, getHeaderSign || defaultGetHeaderSign, {proxy})
     // NOTE this will be removed
     this.bucket = service
     this.service = service


### PR DESCRIPTION
environment: axios v0.18.0

使用示例:

```js
const upyun = require('upyun')
const service = new upyun.Service('your service name', 'your operator name', 'your operator password')
const client = new upyun.Client(service, {
  proxy: {
    host: '127.0.0.1',
    port: 9000,
    auth: {
      username: 'mikeymike',
      password: 'rapunz3l'
    }
});


```

**注意**: 目前除 `formPutFile` 接口外，其余接口均可使用代理（因 `formPutFile` 使用 `form-data` 模块, 其未支持代理功能）


---

### 额外补充

> Fix http adapter to allow HTTPS connections via HTTP (https://github.com/axios/axios/issues/959)

`axios` 版本 `0.18.x` 未支持 `https` 请求走 `http` 代理，`fixed commit` 在其版本 `0.19.0-beta.1` 中发布. 待 `axios` 正式版发布更新再合入 `node-sdk`


