### PR TITLE
返回服务器端显示的错误信息

### DIFF
--- a/upyun/create-req.js
+++ b/upyun/create-req.js
@@ -50,6 +50,7 @@ export default function (endpoint, service, getHeaderSign, {proxy} = {}) {
       }
 
       if (response.status !== 404) {
+        if (response.data && response.data.msg) throw new Error('upyun - ' + response.data.msg);
         throw new Error('upyun - response error: ' + error.message)
       } else {
         return response


### PR DESCRIPTION
您好，目前如果有任何参数错误返回的错误信息仅包含http状态吗不便于识别具体错误原因，比如：

`upyun - response error: 401`

然而很多http状态码是被许多错误复用的，所以加上这个更改后

`upyun - user not exists`

这样会便于用户遇到例如 #41 这样的错误时修复调用配置。